### PR TITLE
Fix error in Storybook

### DIFF
--- a/css-loader-config.js
+++ b/css-loader-config.js
@@ -21,7 +21,7 @@ module.exports = (
     fileExtensions.add(extension)
   }
 
-  if (!isServer) {
+  if (!isServer && config.optimization.splitChunks.cacheGroups) {
     config.optimization.splitChunks.cacheGroups.styles = {
       name: 'styles',
       test: new RegExp(`\\.+(${[...fileExtensions].join('|')})$`),


### PR DESCRIPTION
If I use this plugin for next + storybook, I got error, because cache unavaliable. This PR fixes it.